### PR TITLE
fix/idle-timer-label

### DIFF
--- a/Panel/templates/config.html
+++ b/Panel/templates/config.html
@@ -78,7 +78,7 @@
                 ">
             </div>
             <div class="form-group" style="margin-bottom: 15px;">
-                <label style="color: #b3b3b3; display: block; margin-bottom: 5px;">Wait Time Idle (seconds):</label>
+                <label style="color: #b3b3b3; display: block; margin-bottom: 5px;">Wait Time Idle (minutes):</label>
                 <input type="number" id="cpuWaitTimeIdle" value="{{.cpuConfig.WaitTimeIdle}}" min="0" style="
                     width: 100%;
                     padding: 5px;


### PR DESCRIPTION
The IsDeviceIdle() method accepts minutes as a parameter, but the config page label incorrectly displayed "seconds". Updated the label to accurately reflect the actual unit being used.

https://github.com/laprosa/CorvusMiner/blob/934d27da5dcd4eb1d4a8ee282f2743288477cbb2/Client/src/util.cpp#L210-L233